### PR TITLE
Fix for Variants which are added asynchronously

### DIFF
--- a/core/src/main/groovy/guru/stefma/androidartifacts/AndroidArtifactsPlugin.groovy
+++ b/core/src/main/groovy/guru/stefma/androidartifacts/AndroidArtifactsPlugin.groovy
@@ -32,7 +32,7 @@ class AndroidArtifactsPlugin implements Plugin<Project> {
                 return
             }
 
-            project.android.libraryVariants.each { variant ->
+            project.android.libraryVariants.all { variant ->
                 addArtifact(project, (String) variant.name, new AndroidArtifacts(variant))
             }
         }


### PR DESCRIPTION
From the documentation:
https://docs.gradle.org/current/javadoc/org/gradle/api/DomainObjectCollection.html#all(groovy.lang.Closure)
Executes the given action against all objects in this collection, and any objects subsequently added to this collection.

"subsequently added" variants where ignored