### PR TITLE
Add artifact metadata for pom (name, url, description)

### DIFF
--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -37,6 +37,32 @@ open class ArtifactsExtension {
         licenseSpec = LicenseSpec()
         action.execute(licenseSpec!!)
     }
+
+    /**
+     * The human readable name of this artifact.
+     *
+     * This might differ from the [artifactId]. Example:
+     * - name: Material Components for Android
+     * - artifactId: (com.android.support:design)
+     */
+    var name: String? = null
+
+    /**
+     * The url of the project.
+     *
+     * This is a nice to have property and a nice gesture for projects users
+     * that they know where the project lives.
+     */
+    var url: String? = null
+
+    /**
+     * A short description about this artifact
+     *
+     * What is it good for, how does it differ from other artifacts in the same group? Example
+     * - artifactId: org.reactivestreams:reactive-streams
+     * - description: A Protocol for Asynchronous Non-Blocking Data Sequence
+     */
+    var description: String? = null
 }
 
 class LicenseSpec {

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
@@ -72,15 +72,15 @@ class AndroidArtifactsPlugin : Plugin<Project> {
 
             it.setupMetadata(this, extension)
 
-            it.pom {
-                it.packaging = "aar"
-                it.addConfigurations(configurations)
+            it.pom { pom ->
+                pom.packaging = "aar"
+                pom.addConfigurations(configurations)
 
                 // Add the license if available and Gradle version
                 // is better than 4.7
                 if (GradleVersionComparator(gradle.gradleVersion).betterThan("4.7")) {
                     extension.licenseSpec?.apply {
-                        it.licenses {
+                        pom.licenses {
                             it.license {
                                 it.name.set(name)
                                 it.url.set(url)
@@ -90,6 +90,10 @@ class AndroidArtifactsPlugin : Plugin<Project> {
                         }
                     }
                 }
+
+                pom.url.set(extension.url)
+                pom.description.set(extension.description)
+                pom.name.set(extension.name)
             }
         }
     }

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
@@ -88,12 +88,12 @@ class JavaArtifactsPlugin : Plugin<Project> {
 
             it.setupMetadata(project, extension)
 
-            // Add the license if available and Gradle version
-            // is better than 4.7
-            if (GradleVersionComparator(project.gradle.gradleVersion).betterThan("4.7")) {
-                extension.licenseSpec?.apply {
-                    it.pom {
-                        it.licenses {
+            it.pom { pom ->
+                // Add the license if available and Gradle version
+                // is better than 4.7
+                if (GradleVersionComparator(project.gradle.gradleVersion).betterThan("4.7")) {
+                    extension.licenseSpec?.apply {
+                        pom.licenses {
                             it.license {
                                 it.name.set(name)
                                 it.url.set(url)
@@ -103,7 +103,13 @@ class JavaArtifactsPlugin : Plugin<Project> {
                         }
                     }
                 }
+
+
+                pom.url.set(extension.url)
+                pom.description.set(extension.description)
+                pom.name.set(extension.name)
             }
+
         }
     }
 


### PR DESCRIPTION
Artifacts can have tons of metadata in their pom files. Not all of them have to be supported by this project but supporting the [most common ones](http://maven.apache.org/pom.html#More_Project_Information) would be great!


```groovy
javaArtifact {
    artifactId = 'gitversioner'
    license {
        name = 'The Apache License, Version 2.0'
        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
    }

    // new properties
    name = "Git Versioner gradle plugin"
    description = "Create versions based on the git history"
    url = "https://github.com/passsy/gradle-gitVersioner-plugin"
}
```