### PR TITLE
Gives access to the pom for further configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,8 @@ version = "1.0.0"
 group = "guru.stefma.androidartifacts"
 androidArtifact { // 3
     artifactId = 'androidartifacts'
-    license { // 4
-        name = "Apache License, Version 2.0"
-        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-        distribution = "repo"
-        comments = "A business-friendly OSS license"
+    pom { // 4
+        
     }
 }
 ```
@@ -94,7 +91,7 @@ androidArtifact { // 3
 * **//2:** The `guru.stefma.artifacts` plugin should always be added **after** the `com.android.library`  
 and the `org.jetbrains.kotlin.android` plugin.
 * **//3:** The extension is either named `androidArtifact` **or** `javaArtifact`. Depending on the environment.
-* **//4:** Add a license to the POM file. Will only be added with **Gradle 4.8** and up.
+* **//4:** Customize the POM file directly. See also [this doc](https://docs.gradle.org/current/dsl/org.gradle.api.publish.maven.MavenPom.html) for more.
 
 ## Tasks
 The plugin will automatically create some tasks based on your (Android BuildType/Flavors) setup for you. 

--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -100,14 +100,17 @@ open class ArtifactsExtension {
 }
 
 class LicenseSpec {
+
     /**
      * The name of the license.
      */
     var name: String? = null
+
     /**
      * The url of the license.
      */
     var url: String? = null
+
     /**
      * The distribution type where your artifact
      * will be mainly consumed.
@@ -116,6 +119,7 @@ class LicenseSpec {
      * See also [https://maven.apache.org/pom.html#Licenses][https://maven.apache.org/pom.html#Licenses]
      */
     var distribution: String? = null
+
     /**
      * Some comments about why you have choosen this
      * license.
@@ -124,5 +128,4 @@ class LicenseSpec {
      * > A business-friendly OSS license
      */
     var comments: String? = null
-
 }

--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -1,5 +1,6 @@
 package guru.stefma.androidartifacts
 
+import org.gradle.api.Project
 import org.gradle.api.Action
 import org.gradle.api.publish.maven.MavenPom
 
@@ -29,24 +30,34 @@ open class ArtifactsExtension {
     /**
      * The human readable name of this artifact.
      *
-     * This might differ from the [artifactId]. Example:
-     * - name: Material Components for Android
-     * - artifactId: (com.android.support:design)
+     * This might differ from the [artifactId].
+     * ### Example:
+     * * name: Material Components for Android
+     * * artifactId: (com.android.support:design)
+     *
+     * Default is [Project.getName].
      */
     var name: String? = null
+
     /**
      * The url of the project.
      *
      * This is a nice to have property and a nice gesture for projects users
      * that they know where the project lives.
+     *
+     * Default is `null`.
      */
     var url: String? = null
+
     /**
      * A short description about this artifact
      *
-     * What is it good for, how does it differ from other artifacts in the same group? Example
-     * - artifactId: org.reactivestreams:reactive-streams
-     * - description: A Protocol for Asynchronous Non-Blocking Data Sequence
+     * What is it good for, how does it differ from other artifacts in the same group?
+     * ### Example:
+     * * artifactId: org.reactivestreams:reactive-streams
+     * * description: A Protocol for Asynchronous Non-Blocking Data Sequence
+     *
+     * Default is [Project.getDescription].
      */
     var description: String? = null
 

--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -1,6 +1,7 @@
 package guru.stefma.androidartifacts
 
 import org.gradle.api.Action
+import org.gradle.api.publish.maven.MavenPom
 
 open class ArtifactsExtension {
 
@@ -25,47 +26,39 @@ open class ArtifactsExtension {
      */
     var javadoc: Boolean = true
 
-    internal var licenseSpec: LicenseSpec? = null
+    internal var customPomConfiguration: (Action<MavenPom>)? = null
 
     /**
-     * Set a license to the POM file.
+     * Add additional field to the pom by using the [MavenPom] API
      *
-     * Default is null. Means there will be no <license>-Tag
-     * inside the POM.
+     * ```
+     * javaArtifact {
+     *    artifactId = '$artifactId'
+     *    pom {
+     *        name = "Awesome library"
+     *        description = "Make your project great again"
+     *        url = 'https://github.com/$user/$projectname'
+     *        licenses {
+     *            license {
+     *                name = 'The Apache License, Version 2.0'
+     *                url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+     *            }
+     *        }
+     *
+     *        developers {
+     *            developer {
+     *                id = '$user'
+     *                name = '$fullname'
+     *                email = 'dev@eloper.com'
+     *                url = 'https://github.com/$user'
+     *            }
+     *        }
+     *     }
+     * }
+     * ```
      */
-    fun license(action: Action<LicenseSpec>) {
-        licenseSpec = LicenseSpec()
-        action.execute(licenseSpec!!)
+    fun pom(block: Action<MavenPom>) {
+        customPomConfiguration = block
     }
-}
 
-class LicenseSpec {
-
-    /**
-     * The name of the license.
-     */
-    var name: String? = null
-
-    /**
-     * The url of the license.
-     */
-    var url: String? = null
-
-    /**
-     * The distribution type where your artifact
-     * will be mainly consumed.
-     *
-     * E.g. "repo" or "manually".
-     * See also [https://maven.apache.org/pom.html#Licenses][https://maven.apache.org/pom.html#Licenses]
-     */
-    var distribution: String? = null
-
-    /**
-     * Some comments about why you have choosen this
-     * license.
-     *
-     * E.g.
-     * > A business-friendly OSS license
-     */
-    var comments: String? = null
 }

--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -26,6 +26,43 @@ open class ArtifactsExtension {
      */
     var javadoc: Boolean = true
 
+    /**
+     * The human readable name of this artifact.
+     *
+     * This might differ from the [artifactId]. Example:
+     * - name: Material Components for Android
+     * - artifactId: (com.android.support:design)
+     */
+    var name: String? = null
+    /**
+     * The url of the project.
+     *
+     * This is a nice to have property and a nice gesture for projects users
+     * that they know where the project lives.
+     */
+    var url: String? = null
+    /**
+     * A short description about this artifact
+     *
+     * What is it good for, how does it differ from other artifacts in the same group? Example
+     * - artifactId: org.reactivestreams:reactive-streams
+     * - description: A Protocol for Asynchronous Non-Blocking Data Sequence
+     */
+    var description: String? = null
+
+    internal var licenseSpec: LicenseSpec? = null
+
+    /**
+     * Set a license to the POM file.
+     *
+     * Default is null. Means there will be no <license>-Tag
+     * inside the POM.
+     */
+    fun license(action: Action<LicenseSpec>) {
+        licenseSpec = LicenseSpec()
+        action.execute(licenseSpec!!)
+    }
+
     internal var customPomConfiguration: (Action<MavenPom>)? = null
 
     /**
@@ -57,8 +94,35 @@ open class ArtifactsExtension {
      * }
      * ```
      */
-    fun pom(block: Action<MavenPom>) {
-        customPomConfiguration = block
+    fun pom(action: Action<MavenPom>) {
+        customPomConfiguration = action
     }
+}
+
+class LicenseSpec {
+    /**
+     * The name of the license.
+     */
+    var name: String? = null
+    /**
+     * The url of the license.
+     */
+    var url: String? = null
+    /**
+     * The distribution type where your artifact
+     * will be mainly consumed.
+     *
+     * E.g. "repo" or "manually".
+     * See also [https://maven.apache.org/pom.html#Licenses][https://maven.apache.org/pom.html#Licenses]
+     */
+    var distribution: String? = null
+    /**
+     * Some comments about why you have choosen this
+     * license.
+     *
+     * E.g.
+     * > A business-friendly OSS license
+     */
+    var comments: String? = null
 
 }

--- a/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/ArtifactsExtension.kt
@@ -69,6 +69,7 @@ open class ArtifactsExtension {
      * Default is null. Means there will be no <license>-Tag
      * inside the POM.
      */
+    @Deprecated(message = "Use pom(Action<MavenPom)")
     fun license(action: Action<LicenseSpec>) {
         licenseSpec = LicenseSpec()
         action.execute(licenseSpec!!)

--- a/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
@@ -97,20 +97,32 @@ internal fun MavenPublication.setupMetadata(
     artifactId = extension.artifactId
     groupId = project.group as String
 
-    pom.name.set(extension.name ?: project.name)
-    pom.description.set(extension.description ?: project.description)
-    pom.url.set(extension.url)
+    if (GradleVersionComparator(project.gradle.gradleVersion).betterThan("4.7")) {
+        pom.name.set(extension.name ?: project.name)
+        pom.description.set(extension.description ?: project.description)
+        pom.url.set(extension.url)
 
-    // Add deprecated license property if available
-    extension.licenseSpec?.let { license ->
-        pom.licenses {
-            it.license {
-                it.name.set(license.name)
-                it.url.set(license.url)
-                it.comments.set(license.comments)
-                it.distribution.set(license.distribution)
+        // Add deprecated license property if available
+        extension.licenseSpec?.let { license ->
+            pom.licenses {
+                it.license {
+                    it.name.set(license.name)
+                    it.url.set(license.url)
+                    it.comments.set(license.comments)
+                    it.distribution.set(license.distribution)
+                }
             }
         }
+    } else {
+        // TODO add meta information using `pom.withXml {  }`
+        if (extension.name != null) logger.warn(
+                "property 'name' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
+        if (extension.description != null) logger.warn(
+                "property 'description' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
+        if (extension.url != null) logger.warn(
+                "property 'url' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
+        if (extension.licenseSpec != null) logger.warn(
+                "property 'license' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
     }
 }
 

--- a/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
@@ -85,11 +85,9 @@ internal fun MavenPublication.addJavaDokkaArtifact(project: Project) {
 }
 
 /**
- * Setup the "metadata" for this [MavenPublication].
- *
- * Currently it will setup the [MavenPublication.setVersion], [MavenPublication.setArtifactId] and
- * the [MavenPublication.setGroupId] based on the [ArtifactsExtension.artifactId], [Project.getVersion] and
- * [Project.getGroup]
+ * Setup the "metadata" for this [MavenPublication]. Combines existing information from the [project] (like
+ * [Project.getVersion] and [Project.getGroup]) with information defined in [extension]. All the information is used to
+ * generate the pom file
  */
 internal fun MavenPublication.setupMetadata(
         project: Project,
@@ -98,6 +96,22 @@ internal fun MavenPublication.setupMetadata(
     version = project.version as String
     artifactId = extension.artifactId
     groupId = project.group as String
+
+    pom.name.set(extension.name ?: project.name)
+    pom.description.set(extension.description ?: project.description)
+    pom.url.set(extension.url)
+
+    // Add deprecated license property if available
+    extension.licenseSpec?.let { license ->
+        pom.licenses {
+            it.license {
+                it.name.set(license.name)
+                it.url.set(license.url)
+                it.comments.set(license.comments)
+                it.distribution.set(license.distribution)
+            }
+        }
+    }
 }
 
 /**

--- a/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
@@ -102,6 +102,8 @@ internal fun MavenPublication.setupMetadata(
         pom.description.set(extension.description ?: project.description)
         pom.url.set(extension.url)
 
+        // TODO: Remove we in 2.0.0
+        // license is deprecated
         extension.licenseSpec?.let { license ->
             pom.licenses {
                 it.license {
@@ -120,8 +122,6 @@ internal fun MavenPublication.setupMetadata(
                 "property 'description' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
         if (extension.url != null) logger.warn(
                 "property 'url' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
-        if (extension.licenseSpec != null) logger.warn(
-                "property 'license' of artifact '${extension.artifactId}' is not supported, please upgrade to Gradle 4.8+")
     }
 }
 

--- a/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/MavenPublication.kt
@@ -102,7 +102,6 @@ internal fun MavenPublication.setupMetadata(
         pom.description.set(extension.description ?: project.description)
         pom.url.set(extension.url)
 
-        // Add deprecated license property if available
         extension.licenseSpec?.let { license ->
             pom.licenses {
                 it.license {

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
@@ -7,8 +7,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublicationContainer
 import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.util.GradleVersion
-import org.gradle.util.VersionNumber
 
 /**
  * This Plugin will simplify the process to create [publications][org.gradle.api.publish.Publication]
@@ -72,25 +70,7 @@ class AndroidArtifactsPlugin : Plugin<Project> {
 
             it.setupMetadata(this, extension)
 
-            it.pom {
-                it.packaging = "aar"
-                it.addConfigurations(configurations)
-
-                // Add the license if available and Gradle version
-                // is better than 4.7
-                if (GradleVersionComparator(gradle.gradleVersion).betterThan("4.7")) {
-                    extension.licenseSpec?.apply {
-                        it.licenses {
-                            it.license {
-                                it.name.set(name)
-                                it.url.set(url)
-                                it.comments.set(comments)
-                                it.distribution.set(distribution)
-                            }
-                        }
-                    }
-                }
-            }
+            extension.customPomConfiguration?.execute(it.pom)
         }
     }
 

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPlugin.kt
@@ -68,8 +68,15 @@ class AndroidArtifactsPlugin : Plugin<Project> {
                 if (hasKotlinAndroidPluginApplied) it.addAndroidDokkaArtifact(this, variant)
             }
 
+            // Android artifacts are always aar
+            it.pom.packaging = "aar"
+
             it.setupMetadata(this, extension)
 
+            // add dependencies
+            it.pom.addConfigurations(configurations)
+
+            // Apply custom pom configuration, allowing to override everything
             extension.customPomConfiguration?.execute(it.pom)
         }
     }

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
@@ -88,22 +88,7 @@ class JavaArtifactsPlugin : Plugin<Project> {
 
             it.setupMetadata(project, extension)
 
-            // Add the license if available and Gradle version
-            // is better than 4.7
-            if (GradleVersionComparator(project.gradle.gradleVersion).betterThan("4.7")) {
-                extension.licenseSpec?.apply {
-                    it.pom {
-                        it.licenses {
-                            it.license {
-                                it.name.set(name)
-                                it.url.set(url)
-                                it.comments.set(comments)
-                                it.distribution.set(distribution)
-                            }
-                        }
-                    }
-                }
-            }
+            extension.customPomConfiguration?.execute(it.pom)
         }
     }
 

--- a/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
+++ b/src/main/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPlugin.kt
@@ -75,6 +75,7 @@ class JavaArtifactsPlugin : Plugin<Project> {
     ) {
         publicationNames.publicationNames += publicationName
         project.publishingExtension.publications.create(publicationName, MavenPublication::class.java) {
+            // Adds jar artifacts and and configures dependencies in pom
             it.from(project.components.getByName("java"))
             // Publish sources only if set to true
             if (extension.sources) it.addJavaSourcesArtifact(project)
@@ -88,6 +89,7 @@ class JavaArtifactsPlugin : Plugin<Project> {
 
             it.setupMetadata(project, extension)
 
+            // Apply custom pom configuration, allowing to override everything
             extension.customPomConfiguration?.execute(it.pom)
         }
     }

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPluginTest.kt
@@ -110,6 +110,9 @@ class JavaArtifactsPluginTest {
                         version = "1.0"
                         javaArtifact {
                             artifactId = "androidartifacts"
+                            name = "Android Artifacts"
+                            description = "Example description"
+                            url = "https://github.com/StefMa/AndroidArtifacts"
                             license {
                                 name = "Apache License, Version 2.0"
                                 url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
@@ -127,6 +130,9 @@ class JavaArtifactsPluginTest {
 
         val pomFile = File(tempDir, "/build/publications/maven/pom-default.xml")
         pomFile.assertContainsLicenses()
+        pomFile.assertContainsName()
+        pomFile.assertContainsDescription()
+        pomFile.assertContainsUrl()
     }
 
     private fun File.assertContainsLicenses() =
@@ -141,6 +147,15 @@ class JavaArtifactsPluginTest {
   </licenses>"""
             )
 
+    private fun File.assertContainsName() =
+            assertThat(readText()).contains("<name>Android Artifacts</name>")
+
+    private fun File.assertContainsDescription() =
+            assertThat(readText()).contains("<description>Example description</description>")
+
+    private fun File.assertContainsUrl() =
+            assertThat(readText()).contains("<url>https://github.com/StefMa/AndroidArtifacts</url>")
+
     @Test
     fun `test apply with license should ignore license in pom for Gradle version 4dot7 (and below)`(
             @TempDir tempDir: File,
@@ -152,6 +167,9 @@ class JavaArtifactsPluginTest {
                         version = "1.0"
                         javaArtifact {
                             artifactId = "androidartifacts"
+                            name = "Android Artifacts"
+                            description = "Example description"
+                            url = "https://github.com/StefMa/AndroidArtifacts"
                             license {
                                 name = "Apache License, Version 2.0"
                                 url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
@@ -169,15 +187,27 @@ class JavaArtifactsPluginTest {
 
         val pomFile = File(tempDir, "/build/publications/maven/pom-default.xml")
         pomFile.assertDoesNotContainLicenses()
+        pomFile.assertDoesNotContainName()
+        pomFile.assertDoesNotContainDescription()
+        pomFile.assertDoesNotContainUrl()
     }
 
     private fun File.assertDoesNotContainLicenses() =
             assertThat(readText()).doesNotContain(
                     "<name>Apache License, Version 2.0</name>",
-                    " <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>",
+                    "<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>",
                     "<distribution>repo</distribution>",
                     "<comments>A business-friendly OSS license</comments>"
             )
+
+    private fun File.assertDoesNotContainName() =
+            assertThat(readText()).doesNotContain("<name>Android Artifacts</name>")
+
+    private fun File.assertDoesNotContainDescription() =
+            assertThat(readText()).doesNotContain("<description>Example description</description>")
+
+    private fun File.assertDoesNotContainUrl() =
+            assertThat(readText()).doesNotContain("<url>https://github.com/StefMa/AndroidArtifacts</url>")
 
     @Test
     fun `test apply should generate pom for project correctly`(

--- a/subprojects/consumer/android/build.gradle.kts
+++ b/subprojects/consumer/android/build.gradle.kts
@@ -10,6 +10,9 @@ version = "0.0.1"
 group = "guru.stefma.androidartifacts.consumer"
 configure<guru.stefma.androidartifacts.ArtifactsExtension> {
     artifactId = "android"
+    name = "AndroidArtifacts Android example"
+    description = "Sample implementation generating aar artifacts and sources from an android library project"
+    url = "https://github.com/StefMa/AndroidArtifacts"
     license {
         name = "Apache License, Version 2.0"
         url = "https://www.apache.org/licenses/LICENSE-2.0.txt"

--- a/subprojects/consumer/android/build.gradle.kts
+++ b/subprojects/consumer/android/build.gradle.kts
@@ -13,12 +13,12 @@ configure<guru.stefma.androidartifacts.ArtifactsExtension> {
     name = "AndroidArtifacts Android example"
     description = "Sample implementation generating aar artifacts and sources from an android library project"
     url = "https://github.com/StefMa/AndroidArtifacts"
-    license {
+    license(Action{
         name = "Apache License, Version 2.0"
         url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
         distribution = "repo"
         comments = "A business-friendly OSS license"
-    }
+    })
 }
 
 configure<LibraryExtension> {

--- a/subprojects/consumer/java/build.gradle.kts
+++ b/subprojects/consumer/java/build.gradle.kts
@@ -10,12 +10,12 @@ configure<guru.stefma.androidartifacts.ArtifactsExtension> {
     name = "AndroidArtifacts Java example"
     description = "Sample implementation generating artifacts for pure java projects"
     url = "https://github.com/StefMa/AndroidArtifacts"
-    license {
+    license(Action{
         name = "Apache License, Version 2.0"
         url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
         distribution = "repo"
         comments = "A business-friendly OSS license"
-    }
+    })
 }
 
 repositories {

--- a/subprojects/consumer/java/build.gradle.kts
+++ b/subprojects/consumer/java/build.gradle.kts
@@ -7,6 +7,9 @@ version = "0.0.1"
 group = "guru.stefma.androidartifacts.consumer"
 configure<guru.stefma.androidartifacts.ArtifactsExtension> {
     artifactId = "java"
+    name = "AndroidArtifacts Java example"
+    description = "Sample implementation generating artifacts for pure java projects"
+    url = "https://github.com/StefMa/AndroidArtifacts"
     license {
         name = "Apache License, Version 2.0"
         url = "https://www.apache.org/licenses/LICENSE-2.0.txt"


### PR DESCRIPTION
Adding support for the [most common pom properties](http://maven.apache.org/pom.html#More_Project_Information). Also gives users of this lib direct access to the pom.

Usage (groovy):

```
javaArtifact {
    artifactId = '$artifactId'
    name = "Pretty cool library"
    description = "Does awesome things and improves code"
    url = 'https://github.com/$user/$projectname'
    license {
        name = 'The Apache License, Version 2.0'
        url = 'http://www.apache.org/licenses/LICENSE-2.0.txt'
    }

    pom { // access to raw pom file for additional, non tirival properties
       developers {
           developer {
               id = '$user'
               name = '$fullname'
               email = 'dev@eloper.com'
               url = 'https://github.com/$user'
           }
       }
    }
}
```

Fixes #66 
Fixes #65
Fixes https://github.com/StefMa/bintray-release/issues/26