### PR TITLE
Remove agp as implementation dep

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,16 @@ repositories {
     google()
 }
 
+val optionalPlugins by configurations.creating {
+    configurations["compileOnly"].extendsFrom(this)
+}
+
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
-    implementation("com.android.tools.build:gradle:3.1.4")
     implementation("org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
+
+    optionalPlugins("com.android.tools.build:gradle:3.1.4")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.3.1")
@@ -41,6 +46,11 @@ dependencies {
 
 tasks.withType(Test::class.java) {
     useJUnitPlatform()
+}
+
+// This will add the android tools into the "test classpath"
+tasks.withType<PluginUnderTestMetadata> {
+    pluginClasspath.from(optionalPlugins)
 }
 
 site {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.3.1")
-    testRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.1")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.3.1")
     testImplementation("org.assertj:assertj-core:3.11.1")
 }
 


### PR DESCRIPTION
Fix #60 

To give people (and at least myself) a little bit insight what happend here (or: Why we can't use just `compileOnly`):
The TestKit applies the plugins on a *different* classpath (the runtimeClasspath) when we use the GradleRunner with `withPluginClasspath`.
That means that plugins which are applied differently (e.g. a custom `settings.gradle` in the test) will be added to a **different** classpath than the plugin under test. Which means that the plugin under test will *not found classes from the applied plugins in the test* (at least not from them which are *not* in the `runtimeClasspath`).

So what is the solution:
When we want to use `withPluginClasspath` the **depending plugins**  should be added to the *same* classpath (that it was we do here (in this PR)).
We create a new `configuration` (which is similar to the compileOnly configuration) and add these to the *plugin classpath* (to the task which generated the `plugin-under-test-metadata.properties`).
When we don't want to use `withPluginClasspath` the **plugin under test** needs to be published to the local maven first - and could then applied like the depending plugin.