### PR TITLE
Support as 3.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,7 @@ jobs:
       - run: unzip -q sdk-tools-linux-4333796.zip
       - run: mkdir $HOME/android-sdk
       - run: mv tools $HOME/android-sdk/tools
-      - run: mkdir $HOME/android-sdk/licenses
-      - run: echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > "$HOME/android-sdk/licenses/android-sdk-license"
-      - run: echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$HOME/android-sdk/licenses/android-sdk-preview-license"
+      - run: yes | $HOME/android-sdk/tools/bin/sdkmanager --licenses || true
 
       # Try to restore cache (see ho to save cache below)
       - restore_cache:
@@ -70,9 +68,7 @@ jobs:
     - run: unzip -q sdk-tools-linux-4333796.zip
     - run: mkdir $HOME/android-sdk
     - run: mv tools $HOME/android-sdk/tools
-    - run: mkdir $HOME/android-sdk/licenses
-    - run: echo -e "\nd56f5187479451eabf01fb78af6dfcb131a6481e" > "$HOME/android-sdk/licenses/android-sdk-license"
-    - run: echo -e "\n84831b9409646a918e30573bab4c9c91346d8abd" > "$HOME/android-sdk/licenses/android-sdk-preview-license"
+    - run: yes | $HOME/android-sdk/tools/bin/sdkmanager --licenses || true
 
     - run:
         working_directory: subprojects/consumer

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ jobs:
 
   # This will publish the docs to now without setting an alias.
   "publishDocs":
-    machine:
-      image: circleci/classic:latest
+    docker:
+      - image: openjdk:8u191-jdk-alpine3.8
 
     steps:
     - checkout
@@ -92,13 +92,21 @@ jobs:
           key: gradle-cache-v0-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}    
 
     # First install now
-    - run: npm install -g now
-    - run: ./gradlew publishDocsToNow --zeitToken=$NOW_TOKEN
+    - run: apk update
+    - run: apk add wget
+    - run: wget -q https://github.com/zeit/now-cli/releases/download/13.1.3/now-alpine.gz
+    - run: apk add gzip
+    - run: gunzip now-alpine.gz
+    - run: chmod a+x now-alpine
+    - run: mv now-alpine /usr/local/bin/now
+
+    # Then publish it
+    - run: ./gradlew publishDocsToNow --zeitToken=$NOW_TOKEN --stacktrace
 
   # Same as "publishDocs" but will set an alias afterwards
   "publishDocsWithAlias":
-    machine:
-      image: circleci/classic:latest
+    docker:
+      - image: openjdk:8u191-jdk-alpine3.8
 
     steps:
     - checkout
@@ -108,7 +116,15 @@ jobs:
           key: gradle-cache-v0-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}        
 
     # First install now
-    - run: npm install -g now
+    - run: apk update
+    - run: apk add wget
+    - run: wget -q https://github.com/zeit/now-cli/releases/download/13.1.3/now-alpine.gz
+    - run: apk add gzip
+    - run: gunzip now-alpine.gz
+    - run: chmod a+x now-alpine
+    - run: mv now-alpine /usr/local/bin/now
+
+    # Then publish it
     - run: ./gradlew publishDocsToNow --zeitToken=$NOW_TOKEN createNowAlias --zeitToken=$NOW_TOKEN
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,17 @@ jobs:
             - ~/.gradle
           key: gradle-cache-v0-{{ checksum "build.gradle.kts" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
 
+      - run:
+          name: Save test results
+          command: |
+            mkdir -p ~/test_results/
+            find . -type f -regex ".*/build/test-results/.*xml" -exec cp {} ~/test_results/ \;
+          when: always
+      - store_test_results:
+          path: ~/test_results
+      - store_artifacts:
+          path: ~/test_results
+
   # This job will publish the consumers from
   # the subprojects/consumers dir into the local maven
   "buildConsumersAndStore":

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 apply(plugin = "guru.stefma.bintrayrelease")
 
 group = "guru.stefma.androidartifacts"
-version = "1.3.0"
+version = "1.4.0-SNAPSHOT"
 description = "A Gradle Plugin which will easify the process to publish Android and Java artifacts to the local maven"
 val githubSite = "https://github.com/StefMa/AndroidArtifacts"
 
@@ -52,8 +52,13 @@ dependencies {
     testImplementation("org.assertj:assertj-core:3.11.1")
 }
 
-tasks.withType(Test::class.java) {
-    useJUnitPlatform()
+afterEvaluate {
+    tasks.withType(Test::class.java).configureEach {
+        dependsOn(tasks.named("publishToMavenLocal"))
+        systemProperty("pluginVersion", version)
+
+        useJUnitPlatform()
+    }
 }
 
 // This will add the android tools into the "test classpath"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 apply(plugin = "guru.stefma.bintrayrelease")
 
 group = "guru.stefma.androidartifacts"
-version = "1.4.0-SNAPSHOT"
+version = "1.4.0-NOSNAPSHOT"
 description = "A Gradle Plugin which will easify the process to publish Android and Java artifacts to the local maven"
 val githubSite = "https://github.com/StefMa/AndroidArtifacts"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     implementation("org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.17")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:0.9.17")
 
-    optionalPlugins("com.android.tools.build:gradle:3.1.4")
+    optionalPlugins("com.android.tools.build:gradle:3.3.0")
 
     testImplementation("org.junit.jupiter:junit-jupiter-api:5.3.1")
     testImplementation("org.junit.jupiter:junit-jupiter-params:5.3.1")

--- a/src/test/kotlin/guru/stefma/androidartifacts/internal/AbstractTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/internal/AbstractTest.kt
@@ -12,26 +12,35 @@ interface AbstractTest {
                 writeText("<manifest package=\"guru.stefma.androidartifacts.test\"/>")
             }
 
+    fun withBuildScript(projectDir: File, contentBlock: () -> String) =
+            File(projectDir, "build.gradle").apply {
+                parentFile.mkdirs()
+                createNewFile()
+                writeText(contentBlock())
+            }
+
+    fun withSettingsScript(projectDir: File, contentBlock: () -> String) =
+            File(projectDir, "settings.gradle").apply {
+                parentFile.mkdirs()
+                createNewFile()
+                writeText(contentBlock())
+            }
+
     fun withGradleRunner(
             projectDir: File,
-            buildScriptContent: String,
-            vararg args: String,
+            pluginClasspath: Boolean = true,
+            gradleVersion: String = "4.10.2",
+            args: Array<String> = emptyArray(),
             fail: Boolean = false,
             block: BuildResult.() -> Unit
     ) {
-        createBuildScript(projectDir, buildScriptContent)
-
         GradleRunner.create()
-                .default(projectDir)
+                .apply { if(pluginClasspath) withPluginClasspath() }
+                .withGradleVersion(gradleVersion)
+                .withProjectDir(projectDir)
                 .withArguments(*args)
                 .run { if (fail) buildAndFail() else build() }
                 .also { block(it) }
     }
 
-    private fun createBuildScript(projectDir: File, content: String) =
-            File(projectDir, "build.gradle").apply {
-                parentFile.mkdirs()
-                createNewFile()
-                writeText(content)
-            }
 }

--- a/src/test/kotlin/guru/stefma/androidartifacts/internal/AbstractTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/internal/AbstractTest.kt
@@ -6,6 +6,17 @@ import java.io.File
 
 interface AbstractTest {
 
+    val androidExtensionDefaults
+        get() = """
+                android {
+                    compileSdkVersion 27
+                    defaultConfig {
+                        minSdkVersion 21
+                        targetSdkVersion 28
+                    }
+                }
+            """
+
     fun createAndroidManifest(projectDir: File) =
             File(projectDir, "/src/main/AndroidManifest.xml").apply {
                 parentFile.mkdirs()

--- a/src/test/kotlin/guru/stefma/androidartifacts/internal/GradleRunner.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/internal/GradleRunner.kt
@@ -8,7 +8,7 @@ import java.io.File
  */
 fun GradleRunner.default(
         projectDir: File,
-        gradleVersion: String = "4.8.1",
+        gradleVersion: String = "4.10.2",
         pluginClasspath: Boolean = true
 ) = this
         .apply { if(pluginClasspath) withPluginClasspath() }

--- a/src/test/kotlin/guru/stefma/androidartifacts/internal/GradleRunner.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/internal/GradleRunner.kt
@@ -8,8 +8,9 @@ import java.io.File
  */
 fun GradleRunner.default(
         projectDir: File,
-        gradleVersion: String = "4.8.1"
+        gradleVersion: String = "4.8.1",
+        pluginClasspath: Boolean = true
 ) = this
-        .withPluginClasspath()
+        .apply { if(pluginClasspath) withPluginClasspath() }
         .withGradleVersion(gradleVersion)
         .withProjectDir(projectDir)

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
@@ -1,5 +1,6 @@
 package guru.stefma.androidartifacts.plugin
 
+import guru.stefma.androidartifacts.internal.AbstractTest
 import guru.stefma.androidartifacts.internal.default
 import guru.stefma.androidartifacts.internal.junit.AndroidBuildScript
 import guru.stefma.androidartifacts.internal.junit.AndroidTempDirectory
@@ -14,29 +15,35 @@ import org.junit.jupiter.params.provider.ValueSource
 import java.io.File
 
 @ExtendWith(AndroidTempDirectory::class)
-class AndroidArtifactsPluginTest {
+class AndroidArtifactsPluginTest : AbstractTest {
 
     @Test
-    fun `test apply should generate tasks`(@TempDir tempDir: File, @AndroidBuildScript buildScript: File) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+    fun `test apply should generate tasks`(
+            @TempDir tempDir: File,
+            @AndroidBuildScript buildScript: File
+    ) {
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                """
-        )
+                $androidExtensionDefaults
 
-        val buildResult = GradleRunner.create()
-                .default(tempDir)
-                .withArguments("tasks")
-                .build()
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
+            """
+        }
 
-        buildResult.output.assertContainDebugTasks()
-        buildResult.output.assertContainReleaseTasks()
-        buildResult.output.assertMavenPublicationTasks()
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
+            output.assertContainDebugTasks()
+            output.assertContainReleaseTasks()
+            output.assertMavenPublicationTasks()
+        }
     }
 
     private fun String.assertContainDebugTasks() =
@@ -49,32 +56,39 @@ class AndroidArtifactsPluginTest {
             assertThat(this).contains("generatePomFileForDebugAarPublication", "generatePomFileForReleaseAarPublication")
 
     @Test
-    fun `test apply should generate pom correctly`(@TempDir tempDir: File, @AndroidBuildScript buildScript: File) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+    fun `test apply should generate pom correctly`(
+            @TempDir tempDir: File,
+            @AndroidBuildScript buildScript: File
+    ) {
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        dependencies {
-                            implementation("guru.stefma.androidartifacts:androidartifacts:1.0.0")
-                            api("guru.stefma.artifactorypublish:artifactorypublish:1.0.0")
-                            compileOnly("guru.stefma.bintrayrelease:bintrayrelease:1.0.0")
-                        }
-                """
-        )
+                $androidExtensionDefaults
 
-        GradleRunner.create()
-                .default(tempDir)
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
 
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        pomFile.assertContainsAndroidArtifactsDependency()
-        pomFile.assertContainsArtifactoryPublishDependency()
-        pomFile.assertNotContainBintrayReleaseDependency()
+                dependencies {
+                    implementation("guru.stefma.androidartifacts:androidartifacts:1.0.0")
+                    api("guru.stefma.artifactorypublish:artifactorypublish:1.0.0")
+                    compileOnly("guru.stefma.bintrayrelease:bintrayrelease:1.0.0")
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("generatePomFileForReleaseAarPublication")) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            pomFile.assertContainsAndroidArtifactsDependency()
+            pomFile.assertContainsArtifactoryPublishDependency()
+            pomFile.assertNotContainBintrayReleaseDependency()
+        }
     }
 
     private fun File.assertContainsAndroidArtifactsDependency() =
@@ -109,34 +123,38 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        dependencies {
-                            implementation("guru.stefma.androidartifacts:androidartifacts:1.0.0") {
-                                exclude group: "org.jetbrains.dokka" // exclude both dokka dependencies
-                                exclude module: "kotlin-stdlib-jdk8" // exclude kotlin jvm
-                            }
-                            api("guru.stefma.artifactorypublish:artifactorypublish:1.0.0") {
-                                exclude group: "org.jfrog.buildinfo", module: "build-info-extractor-gradle"
-                            }
-                        }
-                """
-        )
+                $androidExtensionDefaults
 
-        GradleRunner.create()
-                .default(tempDir)
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
 
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        pomFile.assertContainsAndroidArtifactsWithExclusionsDependency()
-        pomFile.assertContainsArtifactoryPublishWithExclusionsDependency()
+                dependencies {
+                    implementation("guru.stefma.androidartifacts:androidartifacts:1.0.0") {
+                        exclude group: "org.jetbrains.dokka" // exclude both dokka dependencies
+                        exclude module: "kotlin-stdlib-jdk8" // exclude kotlin jvm
+                    }
+                    api("guru.stefma.artifactorypublish:artifactorypublish:1.0.0") {
+                        exclude group: "org.jfrog.buildinfo", module: "build-info-extractor-gradle"
+                    }
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("generatePomFileForReleaseAarPublication")) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            pomFile.assertContainsAndroidArtifactsWithExclusionsDependency()
+            pomFile.assertContainsArtifactoryPublishWithExclusionsDependency()
+        }
     }
 
     private fun File.assertContainsAndroidArtifactsWithExclusionsDependency() =
@@ -178,31 +196,36 @@ class AndroidArtifactsPluginTest {
     @Test
     fun `test apply with unknown dependencies should ignore it in pom`(
             @TempDir tempDir: File,
-            @AndroidBuildScript buildScript: File) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+            @AndroidBuildScript buildScript: File
+    ) {
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        dependencies {
-                            implementation(fileTree(include: ['*.jar'], dir: 'libs'))
-                        }
-                """
-        )
+                $androidExtensionDefaults
 
-        val buildResult = GradleRunner.create()
-                .default(tempDir)
-                .withArguments("generatePomFileForReleaseAarPublication", "-i")
-                .build()
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
 
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        // Empty dependencies tag
-        assertThat(pomFile.readText()).contains("<dependencies/>")
-        assertThat(buildResult.output)
-                .contains("One of your dependency has either: 'no group', 'no version' or 'no artifactId")
+                dependencies {
+                    implementation(fileTree(include: ['*.jar'], dir: 'libs'))
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("generatePomFileForReleaseAarPublication", "-i")) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            // Empty dependencies tag
+            assertThat(pomFile.readText()).contains("<dependencies/>")
+            assertThat(output)
+                    .contains("One of your dependency has either: 'no group', 'no version' or 'no artifactId")
+        }
     }
 
     @ParameterizedTest(
@@ -214,29 +237,60 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                            name = "AndroidFacts"
-                            description = "An awesome Gradle plugin for Android publishing"
-                            url = "https://github.com/StefMa/AndroidArtifacts"
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+
+                    name = "AndroidFacts"
+                    description = "An awesome Gradle plugin for Android publishing"
+                    url = "https://github.com/StefMa/AndroidArtifacts"
+                }
+            """
+        }
+
+        withSettingsScript(tempDir) {
+            """
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:3.2.1")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
+                            }
                         }
-                """
-        )
+                    }
+                }
+            """
+        }
 
-        GradleRunner.create()
-                .default(tempDir, gradleVersion)
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
-
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        assertThat(pomFile.readText()).contains("<name>AndroidFacts</name>")
-        assertThat(pomFile.readText()).contains("<description>An awesome Gradle plugin for Android publishing</description>")
-        assertThat(pomFile.readText()).contains("<url>https://github.com/StefMa/AndroidArtifacts</url>")
+        withGradleRunner(
+                tempDir,
+                gradleVersion = gradleVersion,
+                pluginClasspath = false,
+                args = arrayOf("generatePomFileForReleaseAarPublication")
+        ) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            assertThat(pomFile.readText()).contains("<name>AndroidFacts</name>")
+            assertThat(pomFile.readText()).contains("<description>An awesome Gradle plugin for Android publishing</description>")
+            assertThat(pomFile.readText()).contains("<url>https://github.com/StefMa/AndroidArtifacts</url>")
+        }
     }
 
     @Test
@@ -244,29 +298,61 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                            license {
-                                name = "Apache License, Version 2.0"
-                                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                                distribution = "repo"
-                                comments = "A business-friendly OSS license"
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
+
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+
+                    license {
+                        name = "Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
+                        comments = "A business-friendly OSS license"
+                    }
+                }
+            """
+        }
+
+        withSettingsScript(tempDir) {
+            """
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:3.2.1")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
                             }
                         }
-                """
-        )
+                    }
+                }
+            """
+        }
 
-        GradleRunner.create()
-                .default(tempDir, "4.8")
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
-
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        pomFile.assertContainsLicenses()
+        withGradleRunner(
+                tempDir,
+                gradleVersion = "4.8",
+                pluginClasspath = false,
+                args = arrayOf("generatePomFileForReleaseAarPublication")
+        ) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            pomFile.assertContainsLicenses()
+        }
     }
 
     private fun File.assertContainsLicenses() =
@@ -286,29 +372,61 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                            license {
-                                name = "Apache License, Version 2.0"
-                                url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
-                                distribution = "repo"
-                                comments = "A business-friendly OSS license"
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
+
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+
+                    license {
+                        name = "Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0.txt"
+                        distribution = "repo"
+                        comments = "A business-friendly OSS license"
+                    }
+                }
+            """
+        }
+
+        withSettingsScript(tempDir) {
+            """
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:3.2.1")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
                             }
                         }
-                """
-        )
+                    }
+                }
+            """
+        }
 
-        GradleRunner.create()
-                .default(tempDir, "4.7")
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
-
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        pomFile.assertDoesNotContainLicenses()
+        withGradleRunner(
+                tempDir,
+                gradleVersion = "4.7",
+                pluginClasspath = false,
+                args = arrayOf("generatePomFileForReleaseAarPublication")
+        ) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            pomFile.assertDoesNotContainLicenses()
+        }
     }
 
     private fun File.assertDoesNotContainLicenses() =
@@ -324,27 +442,33 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        dependencies {
-                            implementation(project(":awesome"))
-                        }
-                """
-        )
-        File(tempDir, "settings.gradle").apply {
-            parentFile.mkdirs()
-            writeText(
-                    """
-                       include(":awesome")
-                    """
-            )
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
+
+                dependencies {
+                    implementation(project(":awesome"))
+                }
+            """
         }
+
+        withSettingsScript(tempDir) {
+            """
+                include(":awesome")
+            """
+        }
+
         File(tempDir, "awesome/build.gradle").apply {
             parentFile.mkdirs()
             writeText(
@@ -355,13 +479,10 @@ class AndroidArtifactsPluginTest {
             )
         }
 
-        GradleRunner.create()
-                .default(tempDir)
-                .withArguments("generatePomFileForReleaseAarPublication")
-                .build()
-
-        val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
-        pomFile.assertContainsProjectAwesomeDependency()
+        withGradleRunner(tempDir, args = arrayOf("generatePomFileForReleaseAarPublication")) {
+            val pomFile = File(tempDir, "/build/publications/releaseAar/pom-default.xml")
+            pomFile.assertContainsProjectAwesomeDependency()
+        }
     }
 
     private fun File.assertContainsProjectAwesomeDependency() =
@@ -383,20 +504,28 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        repositories {
-                            jcenter()
-                            google()
-                        }
-                """
-        )
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
+
+                repositories {
+                    jcenter()
+                    google()
+                }
+            """
+        }
+
         File(tempDir, "src/main/java/TestFile.java").apply {
             parentFile.mkdirs()
             writeText(
@@ -409,14 +538,43 @@ class AndroidArtifactsPluginTest {
             )
         }
 
-        GradleRunner.create()
-                .default(tempDir, gradleVersion)
-                .withArguments("androidArtifactRelease")
-                .build()
+        val agpVersion = when {
+            listOf("4.4", "4.5", "4.5.1").contains(gradleVersion) -> "3.1.0"
+            "4.10.2" == gradleVersion -> "3.3.0"
+            else -> "3.2.1"
+        }
+        withSettingsScript(tempDir) {
+            """
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:$agpVersion")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
+                            }
+                        }
+                    }
+                }
+            """
+        }
 
-        assertThat(File(tempDir, "/build/outputs/aar/${tempDir.name}-release.aar")).exists()
-        assertThat(File(tempDir, "/build/libs/${tempDir.name}-1.0-sources.jar")).exists()
-        assertThat(File(tempDir, "/build/libs/${tempDir.name}-1.0-javadocs.jar")).exists()
+        withGradleRunner(
+                tempDir,
+                pluginClasspath = false,
+                gradleVersion = gradleVersion,
+                args = arrayOf("androidArtifactRelease")
+        ) {
+            assertThat(File(tempDir, "/build/outputs/aar/${tempDir.name}-release.aar")).exists()
+            assertThat(File(tempDir, "/build/libs/${tempDir.name}-1.0-sources.jar")).exists()
+            assertThat(File(tempDir, "/build/libs/${tempDir.name}-1.0-javadocs.jar")).exists()
+        }
     }
 
     @ParameterizedTest(
@@ -428,22 +586,30 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                            javadoc = false
-                            sources = false
-                        }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        repositories {
-                            jcenter()
-                            google()
-                        }
-                """
-        )
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                    javadoc = false
+                    sources = false
+                }
+
+                repositories {
+                    jcenter()
+                    google()
+                }
+            """
+        }
+
         File(tempDir, "src/main/java/TestFile.java").apply {
             parentFile.mkdirs()
             writeText(
@@ -456,13 +622,42 @@ class AndroidArtifactsPluginTest {
             )
         }
 
-        GradleRunner.create()
-                .default(tempDir, gradleVersion)
-                .withArguments("androidArtifactRelease")
-                .build()
+        val agpVersion = when {
+            listOf("4.4", "4.5", "4.5.1").contains(gradleVersion) -> "3.1.0"
+            "4.10.2" == gradleVersion -> "3.3.0"
+            else -> "3.2.1"
+        }
+        withSettingsScript(tempDir) {
+            """
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:$agpVersion")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
+                            }
+                        }
+                    }
+                }
+            """
+        }
 
-        assertThat(File(tempDir, "/build/outputs/aar/${tempDir.name}-release.aar")).exists()
-        assertThat(File(tempDir, "/build/libs/").listFiles()).isNull()
+        withGradleRunner(
+                tempDir,
+                pluginClasspath = false,
+                gradleVersion = gradleVersion,
+                args = arrayOf("androidArtifactRelease")
+        ) {
+            assertThat(File(tempDir, "/build/outputs/aar/${tempDir.name}-release.aar")).exists()
+            assertThat(File(tempDir, "/build/libs/").listFiles()).isNull()
+        }
     }
 
     @Test
@@ -470,23 +665,30 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
+                }
 
-                        repositories {
-                            jcenter()
-                            google()
-                        }
-                """
-        )
-        File(tempDir, "settings.gradle").apply {
-            createNewFile()
-            writeText("""
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
+
+                repositories {
+                    jcenter()
+                    google()
+                }
+            """
+        }
+
+        withSettingsScript(tempDir) {
+            """
                 pluginManagement {
                     repositories {
                         mavenLocal()
@@ -504,16 +706,17 @@ class AndroidArtifactsPluginTest {
                         }
                     }
                 }
-            """.trimIndent())
+            """
         }
 
-        val buildResult = GradleRunner.create()
-                .default(tempDir, "4.10.2", false)
-                .withArguments("androidArtifactRelease")
-                .build()
-
-        println(buildResult.output)
-        assertThat(buildResult.output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+        withGradleRunner(
+                tempDir,
+                gradleVersion = "4.10.2",
+                pluginClasspath = false,
+                args = arrayOf("androidArtifactRelease")
+        ) {
+            assertThat(output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+        }
     }
 
     @Test
@@ -521,50 +724,35 @@ class AndroidArtifactsPluginTest {
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
-        buildScript.appendText(
-                """
-                        group = "guru.stefma"
-                        version = "1.0"
-                        androidArtifact {
-                            artifactId = "androidartifacts"
-                        }
-
-                        repositories {
-                            jcenter()
-                            google()
-                        }
-                """
-        )
-        File(tempDir, "settings.gradle").apply {
-            createNewFile()
-            writeText("""
-                pluginManagement {
-                    repositories {
-                        mavenLocal()
-                        google()
-                        jcenter()
-                    }
-                    resolutionStrategy {
-                        eachPlugin {
-                            if (requested.id.id.startsWith("com.android")) {
-                                useModule("com.android.tools.build:gradle:3.3.0")
-                            }
-                            if (requested.id.id.startsWith("guru.stefma")) {
-                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
-                            }
-                        }
-                    }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id "com.android.library"
+                    id "guru.stefma.androidartifacts"
                 }
-            """.trimIndent())
+
+                $androidExtensionDefaults
+
+                group = "guru.stefma"
+                version = "1.0"
+                androidArtifact {
+                    artifactId = "androidartifacts"
+                }
+
+                repositories {
+                    jcenter()
+                    google()
+                }
+            """
         }
 
-        val buildResult = GradleRunner.create()
-                .default(tempDir, "4.10.2", false)
-                .withArguments("androidArtifactRelease")
-                .build()
-
-        println(buildResult.output)
-        assertThat(buildResult.output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+        withGradleRunner(
+                tempDir,
+                gradleVersion = "4.10.2",
+                args = arrayOf("androidArtifactRelease")
+        ) {
+            assertThat(output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+        }
     }
 
     @Disabled("It currently not working somehow... ")

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
@@ -465,6 +465,108 @@ class AndroidArtifactsPluginTest {
         assertThat(File(tempDir, "/build/libs/").listFiles()).isNull()
     }
 
+    @Test
+    fun `test AGP 3dot2dot1 should not print warning with Gradle version 4dot10dot2`(
+            @TempDir tempDir: File,
+            @AndroidBuildScript buildScript: File
+    ) {
+        buildScript.appendText(
+                """
+                        group = "guru.stefma"
+                        version = "1.0"
+                        androidArtifact {
+                            artifactId = "androidartifacts"
+                        }
+
+                        repositories {
+                            jcenter()
+                            google()
+                        }
+                """
+        )
+        File(tempDir, "settings.gradle").apply {
+            createNewFile()
+            writeText("""
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:3.2.1")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
+                            }
+                        }
+                    }
+                }
+            """.trimIndent())
+        }
+
+        val buildResult = GradleRunner.create()
+                .default(tempDir, "4.10.2", false)
+                .withArguments("androidArtifactRelease")
+                .build()
+
+        println(buildResult.output)
+        assertThat(buildResult.output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+    }
+
+    @Test
+    fun `test AGP 3dot3dot0 should not print warning with Gradle version 4dot10dot2`(
+            @TempDir tempDir: File,
+            @AndroidBuildScript buildScript: File
+    ) {
+        buildScript.appendText(
+                """
+                        group = "guru.stefma"
+                        version = "1.0"
+                        androidArtifact {
+                            artifactId = "androidartifacts"
+                        }
+
+                        repositories {
+                            jcenter()
+                            google()
+                        }
+                """
+        )
+        File(tempDir, "settings.gradle").apply {
+            createNewFile()
+            writeText("""
+                pluginManagement {
+                    repositories {
+                        mavenLocal()
+                        google()
+                        jcenter()
+                    }
+                    resolutionStrategy {
+                        eachPlugin {
+                            if (requested.id.id.startsWith("com.android")) {
+                                useModule("com.android.tools.build:gradle:3.3.0")
+                            }
+                            if (requested.id.id.startsWith("guru.stefma")) {
+                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
+                            }
+                        }
+                    }
+                }
+            """.trimIndent())
+        }
+
+        val buildResult = GradleRunner.create()
+                .default(tempDir, "4.10.2", false)
+                .withArguments("androidArtifactRelease")
+                .build()
+
+        println(buildResult.output)
+        assertThat(buildResult.output).doesNotContain("API 'variant.getJavaCompiler()' is obsolete")
+    }
+
     @Disabled("It currently not working somehow... ")
     @Test
     fun `test apply kotlin should create dokka task`(@TempDir tempDir: File, @AndroidBuildScript buildScript: File) {

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/AndroidArtifactsPluginTest.kt
@@ -577,12 +577,8 @@ class AndroidArtifactsPluginTest : AbstractTest {
         }
     }
 
-    @ParameterizedTest(
-            name = "test task androidArtifactRelease without sources, javadoc with Gradle version {arguments}"
-    )
-    @ValueSource(strings = ["4.4", "4.5", "4.5.1", "4.6", "4.7", "4.8", "4.8.1", "4.9", "4.10.2"])
+    @Test
     fun `test task androidArtifactRelease without sources, javadoc`(
-            gradleVersion: String,
             @TempDir tempDir: File,
             @AndroidBuildScript buildScript: File
     ) {
@@ -622,39 +618,7 @@ class AndroidArtifactsPluginTest : AbstractTest {
             )
         }
 
-        val agpVersion = when {
-            listOf("4.4", "4.5", "4.5.1").contains(gradleVersion) -> "3.1.0"
-            "4.10.2" == gradleVersion -> "3.3.0"
-            else -> "3.2.1"
-        }
-        withSettingsScript(tempDir) {
-            """
-                pluginManagement {
-                    repositories {
-                        mavenLocal()
-                        google()
-                        jcenter()
-                    }
-                    resolutionStrategy {
-                        eachPlugin {
-                            if (requested.id.id.startsWith("com.android")) {
-                                useModule("com.android.tools.build:gradle:$agpVersion")
-                            }
-                            if (requested.id.id.startsWith("guru.stefma")) {
-                                useModule("guru.stefma.androidartifacts:androidartifacts:${System.getProperty("pluginVersion")}")
-                            }
-                        }
-                    }
-                }
-            """
-        }
-
-        withGradleRunner(
-                tempDir,
-                pluginClasspath = false,
-                gradleVersion = gradleVersion,
-                args = arrayOf("androidArtifactRelease")
-        ) {
+        withGradleRunner(tempDir, args = arrayOf("androidArtifactRelease")) {
             assertThat(File(tempDir, "/build/outputs/aar/${tempDir.name}-release.aar")).exists()
             assertThat(File(tempDir, "/build/libs/").listFiles()).isNull()
         }

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/JavaArtifactsPluginTest.kt
@@ -300,12 +300,8 @@ class JavaArtifactsPluginTest {
         assertThat(File(tempDir, "/build/libs/${tempDir.name}-1.0-javadocs.jar")).exists()
     }
 
-    @ParameterizedTest(
-            name = "test task androidArtifactRelease without sources, javadoc with Gradle version {arguments}"
-    )
-    @ValueSource(strings = ["4.4", "4.5", "4.5.1", "4.6", "4.7", "4.8", "4.8.1", "4.9", "4.10.2"])
+    @Test
     fun `test task androidArtifactJava without sources, javadoc`(
-            gradleVersion: String,
             @TempDir tempDir: File,
             @JavaBuildScript buildScript: File
     ) {
@@ -338,7 +334,7 @@ class JavaArtifactsPluginTest {
         }
 
         GradleRunner.create()
-                .default(tempDir, gradleVersion)
+                .default(tempDir)
                 .withArguments("androidArtifactJava")
                 .build()
 

--- a/src/test/kotlin/guru/stefma/androidartifacts/plugin/UmbrellaArtifactsPluginTest.kt
+++ b/src/test/kotlin/guru/stefma/androidartifacts/plugin/UmbrellaArtifactsPluginTest.kt
@@ -15,19 +15,22 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts after java-library should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("java-library")
-                                id("guru.stefma.artifacts")
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("java-library")
+                    id("guru.stefma.artifacts")
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            javaArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
-        withGradleRunner(tempDir, buildScript, "tasks") {
+                group = "guru.stefma"
+                version = "1"
+                javaArtifact {
+                    artifactId = "umbrella"
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainJavaArtifactsTasks()
             output.assertMavenPublicationTask()
         }
@@ -38,20 +41,22 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts before java-library should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("guru.stefma.artifacts")
-                                id("java-library")
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("guru.stefma.artifacts")
+                    id("java-library")
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            javaArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
+                group = "guru.stefma"
+                version = "1"
+                javaArtifact {
+                    artifactId = "umbrella"
+                }
+            """
+        }
 
-        withGradleRunner(tempDir, buildScript, "tasks") {
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainJavaArtifactsTasks()
             output.assertMavenPublicationTask()
         }
@@ -62,19 +67,22 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts after kotlin-jvm should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("org.jetbrains.kotlin.jvm") version "1.2.71"
-                                id("guru.stefma.artifacts")
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("org.jetbrains.kotlin.jvm") version "1.2.71"
+                    id("guru.stefma.artifacts")
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            javaArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
-        withGradleRunner(tempDir, buildScript, "tasks") {
+                group = "guru.stefma"
+                version = "1"
+                javaArtifact {
+                    artifactId = "umbrella"
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainJavaArtifactsTasks()
             assertThat(output).contains("androidArtifactJavaKdoc")
             output.assertMavenPublicationTask()
@@ -86,19 +94,22 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts before kotlin-jvm should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("guru.stefma.artifacts")
-                                id("org.jetbrains.kotlin.jvm") version "1.2.71"
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("guru.stefma.artifacts")
+                    id("org.jetbrains.kotlin.jvm") version "1.2.71"
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            javaArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
-        withGradleRunner(tempDir, buildScript, "tasks") {
+                group = "guru.stefma"
+                version = "1"
+                javaArtifact {
+                    artifactId = "umbrella"
+                }
+            """
+        }
+
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainJavaArtifactsTasks()
             assertThat(output).contains("androidArtifactJavaKdoc")
             output.assertMavenPublicationTask()
@@ -116,30 +127,32 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts after android-library should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("com.android.library")
-                                id("guru.stefma.artifacts")
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("com.android.library")
+                    id("guru.stefma.artifacts")
+                }
 
-                            android {
-                                compileSdkVersion 27
-                                defaultConfig {
-                                    minSdkVersion 21
-                                    targetSdkVersion 28
-                                }
-                            }
+                android {
+                    compileSdkVersion 27
+                    defaultConfig {
+                        minSdkVersion 21
+                        targetSdkVersion 28
+                    }
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            androidArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
+                group = "guru.stefma"
+                version = "1"
+                androidArtifact {
+                    artifactId = "umbrella"
+                }
+            """
+        }
 
         createAndroidManifest(tempDir)
 
-        withGradleRunner(tempDir, buildScript, "tasks") {
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainDebugArtifactsTasks()
             output.assertContainReleaseArtifactsTasks()
             output.assertDebugReleasePublicationTasks()
@@ -151,30 +164,32 @@ class UmbrellaArtifactsPluginTest : AbstractTest {
     fun `apply artifacts before android-library should generate tasks`(
             @TempDir tempDir: File
     ) {
-        val buildScript = """
-                            plugins {
-                                id("guru.stefma.artifacts")
-                                id("com.android.library")
-                            }
+        withBuildScript(tempDir) {
+            """
+                plugins {
+                    id("guru.stefma.artifacts")
+                    id("com.android.library")
+                }
 
-                            android {
-                                compileSdkVersion 27
-                                defaultConfig {
-                                    minSdkVersion 21
-                                    targetSdkVersion 28
-                                }
-                            }
+                android {
+                    compileSdkVersion 27
+                    defaultConfig {
+                        minSdkVersion 21
+                        targetSdkVersion 28
+                    }
+                }
 
-                            group = "guru.stefma"
-                            version = "1"
-                            androidArtifact {
-                                artifactId = "umbrella"
-                            }
-                        """
+                group = "guru.stefma"
+                version = "1"
+                androidArtifact  {
+                    artifactId = "umbrella"
+                }
+            """
+        }
 
         createAndroidManifest(tempDir)
 
-        withGradleRunner(tempDir, buildScript, "tasks") {
+        withGradleRunner(tempDir, args = arrayOf("tasks")) {
             output.assertContainDebugArtifactsTasks()
             output.assertContainReleaseArtifactsTasks()
             output.assertDebugReleasePublicationTasks()


### PR DESCRIPTION
This fixes #87 and #88 .

Currently I'm not 100 percent satisfied with the solution and there are few things to do:
- [ ] Remove the `afterEvaluated` listener 
- [ ] 👆 I think that requires a Gradle 5.0 update
- [ ] 👆 This required a [site plugin](https://github.com/gradle-guides/gradle-site-plugin) update
- [x] Update all tests with the AbstractTest
- [x] Update consumer
- [x] Think about the versioning...